### PR TITLE
Use container names rather than ID's & Update README.md to mention --privileged

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker-compose up
 
 ```
 docker run -d --name logio -p 28777:28777 -p 28778:28778 temal/logio-server
-docker run -d --link logio:logio -v /var/run/docker.sock:/var/run/docker.sock gerchardon/docker-logio -n `uname -n` -h logio
+docker run -d --privileged --link logio:logio -v /var/run/docker.sock:/var/run/docker.sock gerchardon/docker-logio -n `uname -n` -h logio
 ```
 
 ## Usage as CLI

--- a/index.js
+++ b/index.js
@@ -38,10 +38,12 @@ loghose(opts).pipe(through.obj(function(chunk, enc, cb){
 })).pipe(s);
 
 ee.on('start', function(meta, container) {
-  var id = meta.id.substring(0, 12);
-  s.write('+node|'+program.name+':'+id+'|'+meta.image+'\r\n');
+  container.inspect(function (err, data) {
+    s.write('+node|'+program.name+':'+data.Name+'|'+meta.image+'\r\n');
+  });
 });
 ee.on('stop', function(meta, container) {
-  var id = meta.id.substring(0, 12);
-  s.write('-node|'+program.name+':'+id+'\r\n');
+  container.inspect(function (err, data) {
+    s.write('-node|'+program.name+':'+data.Name+'\r\n');
+  });
 });


### PR DESCRIPTION
- List of running containers use the container name rather than the ID for a more user friendly experience.
- Update the README.md to mention the need of --privileged
